### PR TITLE
ci: use oidc token instead

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           node-version: latest
           registry-url: https://registry.npmjs.org
           cache: pnpm
+      - name: Update npm to 11.5.1 or higher
+        run: npm install --global npm@latest
       - run: pnpm install
       - run: pnpm publish --provenance --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to use the latest npm version prior to install/publish steps.
  * Simplified publishing authentication by removing an explicit token environment variable from the workflow.
  * Retained existing checkout, setup, install, and publish steps with the new update step inserted.
  * No changes to application behavior or public APIs; end-users will not see functional differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->